### PR TITLE
Fix network name response when using autocreated networks

### DIFF
--- a/quickstart/rest/servers.py
+++ b/quickstart/rest/servers.py
@@ -290,7 +290,7 @@ class Servers(generic.View):
             {
                 "instance": instance.to_dict(),
                 "email": user_email,
-                "network": PRIVATE_NETWORK
+                "network": PRIVATE_NETWORK if USE_PRIVATE_NETWORK else autonetwork_name(request)
             }
         )
 


### PR DESCRIPTION
When using `openstack-horizon-quickstart` to autocreate network, quickstart screen `Instance created` screen shows IP address of newly created instance as `undefined`. This PR fixes the issue. 